### PR TITLE
SCC-2159 Add handling for no schema cases

### DIFF
--- a/lib/kinesis_client.rb
+++ b/lib/kinesis_client.rb
@@ -9,7 +9,12 @@ class KinesisClient
 
   def initialize(config)
     @config = config
-    @avro = NYPLAvro.by_name(config[:schema_string])
+    @avro = nil
+
+    if config[:schema_string]
+      @avro = NYPLAvro.by_name(config[:schema_string])
+    end
+
   end
 
   def <<(json_message)

--- a/spec/kinesis_client/kinesis_client_spec.rb
+++ b/spec/kinesis_client/kinesis_client_spec.rb
@@ -54,6 +54,11 @@ describe KinesisClient do
       expect(kinesis_client.instance_variable_get(:@avro)).to eq(mock_avro)
     end
 
+    it "should set avro to nil if no schema_string provided" do
+      kinesis_client = KinesisClient.new({})
+      expect(kinesis_client.instance_variable_get(:@avro)).to eq(nil)
+    end
+
   end
 
   describe "writing a message" do


### PR DESCRIPTION
This adds a simple conditional to handle the case when an avro schema name is not provided to the kinesis client. This is handled in the invocation already but this removes a bug that causes the initializer to fail because a schema is not provided.

One test is added to cover this condition as well