### PR TITLE
SCC-2159 Minor Avro and Kinesis Improvements

### DIFF
--- a/lib/kinesis_client.rb
+++ b/lib/kinesis_client.rb
@@ -26,7 +26,7 @@ class KinesisClient
     end
 
     client = Aws::Kinesis::Client.new
-    partition_key = (config[:partition_key] ? json_message[config[:partition_key]] : SecureRandom.hex(20)).hash
+    partition_key = (config[:partition_key] ? json_message[config[:partition_key]] : SecureRandom.hex(20)).hash.to_s
 
     resp = client.put_record({
       stream_name: config[:stream_name],

--- a/lib/nypl_avro.rb
+++ b/lib/nypl_avro.rb
@@ -38,6 +38,7 @@ class NYPLAvro
       bin_encoder.write(decoded_data, encoder)
     rescue Avro::IO::AVroTypeError => e
       raise AvroError.new(e), "Error encoding data using #{@schema.name} schema"
+    end
 
     buffer.rewind
     result = buffer.read

--- a/lib/nypl_avro.rb
+++ b/lib/nypl_avro.rb
@@ -33,7 +33,12 @@ class NYPLAvro
     bin_encoder = Avro::IO::DatumWriter.new(@schema)
     buffer = StringIO.new
     encoder = Avro::IO::BinaryEncoder.new(buffer)
-    bin_encoder.write(decoded_data, encoder)
+
+    begin
+      bin_encoder.write(decoded_data, encoder)
+    rescue Avro::IO::AVroTypeError => e
+      raise AvroError.new(e), "Error encoding data using #{@schema.name} schema"
+
     buffer.rewind
     result = buffer.read
     base64 ? Base64.encode64(result) : result

--- a/lib/nypl_avro.rb
+++ b/lib/nypl_avro.rb
@@ -37,7 +37,7 @@ class NYPLAvro
     begin
       bin_encoder.write(decoded_data, encoder)
     rescue Avro::IO::AvroTypeError => e
-      raise AvroError.new(e), "Error encoding data using #{@schema.name} schema"
+      raise AvroError.new(e), "Error encoding data using #{@schema.name} schema due to #{e.message}"
     end
 
     buffer.rewind

--- a/lib/nypl_avro.rb
+++ b/lib/nypl_avro.rb
@@ -36,7 +36,7 @@ class NYPLAvro
 
     begin
       bin_encoder.write(decoded_data, encoder)
-    rescue Avro::IO::AVroTypeError => e
+    rescue Avro::IO::AvroTypeError => e
       raise AvroError.new(e), "Error encoding data using #{@schema.name} schema"
     end
 


### PR DESCRIPTION
This incorporates two improvements to the ruby utils:

1) It returns a more informative error message when a record fails avro encoding
2) It sets the hash generated for the Kinesis `partition_key` to be converted to a string, as AWS expects the key to be a string