### PR TITLE
NOREF Output UTF-8 string from Avro encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## v0.0.3
-
-Remove base64 encoding on write in the KinesisClient.
+### Fixed
+- Remove base64 encoding on write in the KinesisClient.
+- Add UTF-8 encoding for StringIO object in NYPLAvro.
 
 ## v0.0.0
 

--- a/lib/nypl_avro.rb
+++ b/lib/nypl_avro.rb
@@ -32,6 +32,7 @@ class NYPLAvro
   def encode(decoded_data, base64 = true)
     bin_encoder = Avro::IO::DatumWriter.new(@schema)
     buffer = StringIO.new
+    buffer.set_encoding('UTF-8')
     encoder = Avro::IO::BinaryEncoder.new(buffer)
 
     begin

--- a/spec/nypl_avro/nypl_avro_spec.rb
+++ b/spec/nypl_avro/nypl_avro_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'json'
+require_relative '../../lib/nypl_avro'
+
+AvroClient = NYPLRubyUtil::NYPLAvro
+
+mock_schema = JSON.dump({
+    "name" => "TestRecord",
+    "type" => "record",
+    "fields" => [
+        {
+            "name" => "id",
+            "type" => "int"
+        }
+    ]
+})
+
+describe AvroClient do
+  describe :config do
+    it "should initialize config with schema" do
+        test_avro = AvroClient.new(mock_schema)
+        expect(test_avro.instance_variable_get(:@reader).class).to eq(Avro::IO::DatumReader)
+    end
+  end
+
+  describe :encode do
+    it "should return utf-8 encoded string with Base64 set to false" do
+      test_avro = AvroClient.new(mock_schema)
+      encoded_rec = test_avro.encode({ 'id' => 1 }, base64=false)
+      expect(encoded_rec.class).to eq(String)
+      expect(encoded_rec.encoding).to eq(Encoding::UTF_8)
+
+      # Decode to verify that it works
+      decoded_rec = test_avro.decode(encoded_rec, base64=false)
+      expect(decoded_rec['id']).to eq(1)
+    end
+
+    it "should return bas64 string with default Base64=true" do
+      test_avro = AvroClient.new(mock_schema)
+      encoded_rec = test_avro.encode({ 'id' => 1 })
+      expect(encoded_rec.class).to eq(String)
+      # Intended because we can trust the set of ASCII characters in a bas64 string
+      expect(encoded_rec.encoding).to eq(Encoding::US_ASCII)
+
+      # Decode to verify that it works
+      decoded_rec = test_avro.decode(encoded_rec)
+      expect(decoded_rec['id']).to eq(1)
+    end
+
+    it "should raise an AvroError if the record being encoded does not match the schema" do
+      test_avro = AvroClient.new(mock_schema)
+      expect { test_avro.send(:encode, { 'other' => 'thing' })}.to raise_error(AvroError)
+    end
+  end
+end


### PR DESCRIPTION
When not base64 encoding Avro records, the method should return a UTF-8 encoded string. Otherwise other modules such as logging and JSON cannot handle the ASCII string that is usually returned.

This enforces this by setting the encoding on the StringIO object that generates the returned string from the encode method. This should make it safe to use in all contexts.

If base64 encoding the result the string is still in ASCII, though this is safe as a base64 string can be trusted to contain only well-formed/parseable characters