### PR TITLE
Noref kinesis configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.0.9
+- Add generic `custom_aws_config` in `KinesisClient`
+
 ## v0.0.8
 - Error logging for batched records in Kinesis Client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.0.8
+Add addition custom_aws_config as option in KinesisClient
+
 ## v0.0.7
 Add batching of records in KinesisClient
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This gem contains several utility classes for common tasks in Ruby applications 
 
 ## Version
 
-`0.0.8`
+`0.0.9`
 
 ## Installation
 
@@ -267,7 +267,7 @@ If `config[:automatically_push]` is set to false, it will not push records to ki
 
 Call `push_records` when all records have been entered to push any remaining records to kinesis
 
-Method `push_record` is currently broken. 
+Method `push_record` is currently broken.
 
 ### Deploying In CI/CD
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This gem contains several utility classes for common tasks in Ruby applications 
 
 ## Version
 
-`0.0.6`
+`0.0.8`
 
 ## Installation
 
@@ -240,6 +240,11 @@ The currently used parameters for config are:
 `stream_name` The name of the Kinesis stream
 
 `profile` For local use
+
+`custom_aws_config` An object passed to the Aws Kinesis Client instead of `profile`, when more specific configuration is necessary, e.g.
+```
+{ region: 'region', access_key_id: 'access_key_id', secret_access_key: 'secret_access_key'}
+```
 
 
 

--- a/lib/kinesis_client.rb
+++ b/lib/kinesis_client.rb
@@ -12,14 +12,10 @@ class KinesisClient
     @stream_name = @config[:stream_name]
     @avro = nil
     @batch_size = @config[:batch_size] || 1
-    @batch = []
-    @automatically_push = @config[:automatically_push] == false ? false : true
     @client_options = set_config(config)
-    @client = Aws::Kinesis::Client.new @client_options
     @batch_count = 0
     @records = []
     @automatically_push = !(@config[:automatically_push] == false)
-    @client_options = config[:profile] ? { profile: config[:profile] } : {}
     @client = Aws::Kinesis::Client.new(@client_options)
 
     @avro = NYPLAvro.by_name(config[:schema_string]) if config[:schema_string]

--- a/lib/kinesis_client.rb
+++ b/lib/kinesis_client.rb
@@ -14,7 +14,7 @@ class KinesisClient
     @batch_size = @config[:batch_size] || 1
     @batch = []
     @automatically_push = @config[:automatically_push] == false ? false : true
-    @client_options = config[:profile] ? { profile: config[:profile] } : {}
+    @client_options = set_config(config)
     @client = Aws::Kinesis::Client.new @client_options
 
     if config[:schema_string]
@@ -23,6 +23,16 @@ class KinesisClient
 
     @shovel_method = @batch_size > 1 ? :push_to_batch : :push_record
 
+  end
+
+  def set_config(config)
+    if config[:profile]
+      { profile: config[:profile] }
+    elsif config[:custom_aws_config]
+      config[:custom_aws_config]
+    else
+      {}
+    end
   end
 
   def convert_to_record(json_message)

--- a/nypl_ruby_util.gemspec
+++ b/nypl_ruby_util.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "nypl_ruby_util"
-  s.version = "0.0.8"
+  s.version = "0.0.9"
   s.date = "2020-09-08"
   s.description = "A repository of common utilities for NYPL Ruby application"
   s.summary = "A repository of common utilities for NYPL Ruby application"

--- a/nypl_ruby_util.gemspec
+++ b/nypl_ruby_util.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "nypl_ruby_util"
-  s.version = "0.0.7"
+  s.version = "0.0.8"
   s.date = "2020-09-08"
   s.description = "A repository of common utilities for NYPL Ruby application"
   s.summary = "A repository of common utilities for NYPL Ruby application"

--- a/spec/kinesis_client/kinesis_client_spec.rb
+++ b/spec/kinesis_client/kinesis_client_spec.rb
@@ -61,6 +61,29 @@ describe KinesisClient do
 
   end
 
+  describe 'initializing with custom config' do
+
+    before do
+      @mock_client = double()
+      allow(Aws::Kinesis::Client).to receive(:new).and_return(@mock_client)
+
+    end
+
+    it 'should pass custom creds to Aws client' do
+      expect(Aws::Kinesis::Client).to receive(:new).with(
+        { region: 'region', access_key_id: 'access_key_id', secret_access_key: 'secret_access_key'}
+      )
+
+      KinesisClient.new(
+        {
+          custom_aws_config: {
+            region: 'region', access_key_id: 'access_key_id', secret_access_key: 'secret_access_key'
+          }
+        }
+      )
+    end
+  end
+
   describe 'writing messages in batches' do
 
     before(:each) do


### PR DESCRIPTION
For the PCReservePoller, we can't just rely on the `profile` for credentials, because the application will run in a Docker Container configured on AWS. 

This change allows us to pass any configuration options the application wants to the Aws Kinesis Client.