### PR TITLE
Fix bug retrying platform requests in case of 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.0.10
+- Fix bug in retrying platform api requests in case of authentication errors
+
 ## v0.0.9
 - Add generic `custom_aws_config` in `KinesisClient`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This gem contains several utility classes for common tasks in Ruby applications 
 
 ## Version
 
-`0.0.9`
+`0.0.10`
 
 ## Installation
 

--- a/lib/platform_api_client.rb
+++ b/lib/platform_api_client.rb
@@ -97,7 +97,7 @@ class PlatformApiClient
         if transaction_data[:try_count] < 1
           # Likely an expired access-token; Wipe it for next run
           transaction_data[:try_count] += 1
-          access_token = nil
+          self.access_token = nil
           get(path, transaction_data)
         else
           raise "Error interpretting response for path #{path}: (#{response.code}): #{response.body}"

--- a/spec/platform_api_client/platform_api_client_spec.rb
+++ b/spec/platform_api_client/platform_api_client_spec.rb
@@ -21,13 +21,6 @@ describe PlatformApiClient do
 
 
     it "should retry in case of 401 response" do
-      # unauthorized_response = double
-      # allow(unauthorized_response).to receive(:code).and_return(401)
-      # authorized_response = double
-      # allow(authorized_response).to receive(:code).and_return(200)
-      # authorized_response_body = { success: true }.to_json
-      # allow(authorized_response).to receive(:body).and_return(authorized_response_body)
-      # allow(Net::HTTP).to receive(:start).and_return(unauthorized_response, authorized_response)
       stub_request(:any, /oauth/).to_return(body: { "access_token" => "token" }.to_json, status: 200)
       stub_request(:any, /platform/).to_return(
         { body: "not authenticated".to_json, status: 401 },

--- a/spec/platform_api_client/platform_api_client_spec.rb
+++ b/spec/platform_api_client/platform_api_client_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'net/http'
+require_relative '../../lib/platform_api_client'
+require_relative '../../lib/kms_client'
+
+describe PlatformApiClient do
+
+  describe "get" do
+    before do
+      ENV['NYPL_OAUTH_ID'] = 'oauth_id'
+      ENV['NYPL_OAUTH_SECRET'] = 'oauth_secret'
+      ENV['NYPL_OAUTH_URL'] = 'http://www.fake_oauth.com/'
+      ENV['PLATFORM_API_BASE_URL'] = 'http://www.fake-platform.com/'
+      mock_kms_client = double
+      mock_logger = double
+      $logger = mock_logger
+      allow(mock_logger).to receive(:debug).and_return(nil)
+      allow(KmsClient).to receive(:new).and_return(mock_kms_client)
+      allow(mock_kms_client).to receive(:decrypt).and_return('decrypted')
+    end
+
+
+    it "should retry in case of 401 response" do
+      # unauthorized_response = double
+      # allow(unauthorized_response).to receive(:code).and_return(401)
+      # authorized_response = double
+      # allow(authorized_response).to receive(:code).and_return(200)
+      # authorized_response_body = { success: true }.to_json
+      # allow(authorized_response).to receive(:body).and_return(authorized_response_body)
+      # allow(Net::HTTP).to receive(:start).and_return(unauthorized_response, authorized_response)
+      stub_request(:any, /oauth/).to_return(body: { "access_token" => "token" }.to_json, status: 200)
+      stub_request(:any, /platform/).to_return(
+        { body: "not authenticated".to_json, status: 401 },
+        { body: "success".to_json, status: 200 }
+      )
+      platform_api_client = PlatformApiClient.new
+      expect(platform_api_client.get('fake_path')).to eql("success")
+    end
+  end
+
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'nypl_ruby_util')
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
The Platform API Client is supposed to re-authenticate and retry requests if it receives a 401 (not authenticated code). It should only retry once. This was implemented using an instance variable `@try_count`. However, this instance variable was never initialized, leading to errors when the client encountered a 401. 

The current PR fixes this issue, however a change of approach is required. Originally, the Platform API client was intended to wrap a single request. However, in the PC Reserve Poller we only initialize the Platform API Client once, to avoid memory issues. This means that an instance variable is not the right approach, since it would leak between requests. So this has been replaced with an argument `transaction_data`, which is passed between the `get` method and any methods called by `get`, to make sure the `try_count`, which is now part of the `transaction_data`, is scoped to a single get invocation.

Summary of changes:
- Add `transaction_data` as an argument to `get` and related methods
- Remove `@try_count`
- initialize `transaction_data[:try_count]`
- Add tests
- Update version number

